### PR TITLE
Avoid duplicate logging and remove log parameters from Runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
+        os: ["ubuntu-latest"]
         python-version: ["3.8", "3.9", "3.10"]
         experimental: [false]
         include:

--- a/trollflow2/__init__.py
+++ b/trollflow2/__init__.py
@@ -25,7 +25,11 @@
 # are not necessary
 """Base module for trollflow2."""
 
+from multiprocessing import Manager
+
 from pkg_resources import DistributionNotFound, get_distribution
+
+MP_MANAGER = Manager()
 
 try:
     __version__ = get_distribution(__name__).version

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -354,7 +354,10 @@ def queue_logged_process(msg, prod_list, produced_files):
     with suppress(ValueError):
         signal.signal(signal.SIGUSR1, print_traces)
         logger.debug("Use SIGUSR1 on pid {} to check the current tracebacks of this subprocess.".format(os.getpid()))
-    process(msg, prod_list, produced_files)
+    try:
+        process(msg, prod_list, produced_files)
+    finally:
+        logging.shutdown()
 
 
 def print_traces(signum, frame):

--- a/trollflow2/launcher.py
+++ b/trollflow2/launcher.py
@@ -176,10 +176,9 @@ class Runner:
     """Class that handles all the administration around running on a product list."""
 
     def __init__(self, product_list, connection_parameters=None,
-                 test_message=None, threaded=False, log_config=None):
+                 test_message=None, threaded=False):
         """Set up the runner."""
         self.product_list = product_list
-        self.log_config = log_config
         self.connection_parameters = connection_parameters
         self.test_message = get_test_message(test_message)
         self.threaded = threaded
@@ -224,14 +223,12 @@ class Runner:
         logger.debug("Launching trollflow2 with subprocesses")
         self._run_product_list_on_messages(messages, queue_logged_process, create_logged_process)
 
-    def _run_product_list_on_messages(self, messages, target_fun, process_class):
+    def _run_product_list_on_messages(self, messages, target_fun, process_creator):
         """Run the product list on the messages."""
         for msg in messages:
             produced_files_queue = MP_MANAGER.Queue()
             kwargs = dict(produced_files=produced_files_queue, prod_list=self.product_list)
-            if not self.threaded:
-                kwargs["log_config"] = self.log_config
-            proc = process_class(target=target_fun, args=(msg,), kwargs=kwargs)
+            proc = process_creator(target=target_fun, args=(msg,), kwargs=kwargs)
             start_time = datetime.now()
             proc.start()
             proc.join()
@@ -481,8 +478,7 @@ def launch(args_in):
         threaded = args.pop("threaded")
         connection_parameters = args
 
-        runner = Runner(product_list, connection_parameters, test_message, threaded,
-                        log_config=log_config)
+        runner = Runner(product_list, connection_parameters, test_message, threaded)
         runner.run()
 
 

--- a/trollflow2/logging.py
+++ b/trollflow2/logging.py
@@ -27,6 +27,8 @@ from contextlib import contextmanager
 from logging import getLogger
 from logging.handlers import QueueHandler, QueueListener
 
+from trollflow2 import MP_MANAGER
+
 DEFAULT_LOG_CONFIG = {'version': 1,
                       'disable_existing_loggers': False,
                       'formatters': {'pytroll': {'format': '[%(levelname)s: %(asctime)s : %(name)s] %(message)s',
@@ -35,9 +37,11 @@ DEFAULT_LOG_CONFIG = {'version': 1,
                                                'formatter': 'pytroll'}},
                       'root': {'level': 'DEBUG', 'handlers': ['console']}}
 
+LOG_QUEUE = MP_MANAGER.Queue()
+
 
 @contextmanager
-def logging_on(log_queue, config=None):
+def logging_on(config=None):
     """Activate queued logging.
 
     This context activates logging through the use of logging's QueueHandler and
@@ -52,7 +56,7 @@ def logging_on(log_queue, config=None):
     _set_config(config)
     root.handlers.extend(handlers)
     # set up and run listener
-    listener = QueueListener(log_queue, *(root.handlers))
+    listener = QueueListener(LOG_QUEUE, *(root.handlers))
     listener.start()
     try:
         yield

--- a/trollflow2/tests/test_logging.py
+++ b/trollflow2/tests/test_logging.py
@@ -85,7 +85,7 @@ def test_queued_logging_process_custom_config(caplog):
     }
 
     with logging_on(log_config):
-        run_subprocess(["logger_1", "logger_2"], log_config)
+        run_subprocess(["logger_1", "logger_2"])
 
     assert "root debug" not in caplog.text
     assert "root info" not in caplog.text
@@ -108,7 +108,7 @@ def test_log_config_is_used_when_provided():
 
     logger = logging.getLogger()
     with mock.patch("logging.handlers.BufferingHandler.emit", autospec=True) as emit:
-        with logging_on(config=config):
+        with logging_on(config):
             assert not emit.called
             logger.warning("uh oh...")
             # we wait for the log record to go through the queue listener in
@@ -127,9 +127,9 @@ def test_logging_works(caplog):
     assert message in caplog.text
 
 
-def run_subprocess(loggers, config=None):
+def run_subprocess(loggers):
     """Run a subprocess."""
-    proc = create_logged_process(target=fun, args=(loggers,), kwargs={"log_config": config})
+    proc = create_logged_process(target=fun, args=(loggers,))
     proc.start()
     proc.join()
 
@@ -187,7 +187,7 @@ def test_logging_works_in_subprocess_not_double(tmp_path):
                           }
 
     with logging_on(LOG_CONFIG_TO_FILE):
-        run_subprocess(["foo1", "foo2"], LOG_CONFIG_TO_FILE)
+        run_subprocess(["foo1", "foo2"])
     time.sleep(.1)
     logger.handlers[0].flush()
     with open(logfile) as fd:

--- a/trollflow2/tests/test_logging.py
+++ b/trollflow2/tests/test_logging.py
@@ -120,7 +120,6 @@ def test_log_config_is_used_when_provided():
 def test_logging_works(caplog):
     """Test that the logs get out there."""
     logger = logging.getLogger("something")
-    # logging.getLogger().addHandler(caplog.handler)
     message = "oh no :("
     with logging_on():
         logger.warning(message)

--- a/trollflow2/tests/test_logging.py
+++ b/trollflow2/tests/test_logging.py
@@ -69,7 +69,7 @@ def test_queued_logging_process_custom_config(caplog):
             },
         },
         'loggers': {
-            'root': {
+            '': {
                 'level': 'WARNING',
                 'handlers': ['console'],
             },
@@ -96,10 +96,10 @@ def test_queued_logging_process_custom_config(caplog):
 
 BUFFERING_LOG_CONFIG = {'version': 1,
                         'formatters': {'simple': {'format': '%(asctime)s - %(name)s - %(levelname)s - %(message)s'}},
-                        'handlers': {'file': {'class': 'logging.handlers.BufferingHandler',
-                                              'capacity': 1,
-                                              'formatter': 'simple'}},
-                        'root': {'level': 'INFO', 'handlers': ['file']}}
+                        'handlers': {'buffer': {'class': 'logging.handlers.BufferingHandler',
+                                                'capacity': 1,
+                                                'formatter': 'simple'}},
+                        'root': {'level': 'INFO', 'handlers': ['buffer']}}
 
 
 def test_log_config_is_used_when_provided():
@@ -172,14 +172,13 @@ def test_logging_works_in_subprocess_with_default_logging_config(caplog):
 def test_logging_works_in_subprocess_not_double(tmp_path):
     """Test that the logs get to a file, even from a subprocess, without duplicate lines."""
     logfile = tmp_path / "mylog"
-    logger = logging.getLogger()
     LOG_CONFIG_TO_FILE = {'version': 1,
                           'formatters': {'simple': {'format': '%(asctime)s - %(name)s - %(levelname)s - %(message)s'}},
                           'handlers': {'file': {'class': 'logging.FileHandler',
                                                 'filename': logfile,
                                                 'formatter': 'simple'}},
                           "loggers":
-                              {'root': {'level': 'WARNING', 'handlers': ['file']},
+                              {'': {'level': 'WARNING', 'handlers': ['file']},
                                'foo1': {'level': 'DEBUG'},
                                'foo2': {'level': 'INFO'},
                                }
@@ -187,8 +186,6 @@ def test_logging_works_in_subprocess_not_double(tmp_path):
 
     with logging_on(LOG_CONFIG_TO_FILE):
         run_subprocess(["foo1", "foo2"])
-    time.sleep(.1)
-    logger.handlers[0].flush()
     with open(logfile) as fd:
         file_contents = fd.read()
 

--- a/trollflow2/tests/test_logging.py
+++ b/trollflow2/tests/test_logging.py
@@ -31,13 +31,13 @@ import pytest
 
 from trollflow2.logging import logging_on, setup_queued_logging
 
-log_queue = Manager().Queue(-1)  # no limit on size
+LOG_QUEUE = Manager().Queue(-1)  # no limit on size
 
 
 def test_queued_logging_has_a_listener():
     """Test that the queued logging has a listener."""
     with mock.patch("trollflow2.logging.QueueListener", autospec=True) as q_listener:
-        with logging_on(log_queue):
+        with logging_on(LOG_QUEUE):
             assert q_listener.called
             assert q_listener.return_value.start.called
         assert q_listener.return_value.stop.called
@@ -47,33 +47,18 @@ def test_queued_logging_stops_listener_on_exception():
     """Test that queued logging stops the listener even if an exception occurs."""
     with mock.patch("trollflow2.logging.QueueListener", autospec=True) as q_listener:
         with pytest.raises(Exception, match='Oh no!'):
-            with logging_on(log_queue):
+            with logging_on(LOG_QUEUE):
                 raise Exception("Oh no!")
         assert q_listener.return_value.stop.called
 
 
 def test_queued_logging_process_default_config(caplog):
     """Test default config for queued logging started in a process."""
-    _run_in_process()
-
+    with logging_on(LOG_QUEUE):
+        run_subprocess(["logger_1", "logger_2"], LOG_QUEUE)
     assert "root debug" in caplog.text
     assert "logger_1 debug" in caplog.text
     assert "logger_2 debug" in caplog.text
-
-
-def _run_in_process(log_config=None):
-    from multiprocessing import Manager, get_context
-
-    from trollflow2.logging import logging_on
-
-    log_queue = Manager().Queue()
-
-    with logging_on(log_queue, config=log_config):
-        kwargs = {'log_config': log_config}
-        ctx = get_context("spawn")
-        proc = ctx.Process(target=_queue_logged_process, args=(log_queue,), kwargs=kwargs)
-        proc.start()
-        proc.join()
 
 
 def test_queued_logging_process_custom_config(caplog):
@@ -101,7 +86,8 @@ def test_queued_logging_process_custom_config(caplog):
         },
     }
 
-    _run_in_process(log_config=log_config)
+    with logging_on(LOG_QUEUE, log_config):
+        run_subprocess(["logger_1", "logger_2"], LOG_QUEUE, log_config)
 
     assert "root debug" not in caplog.text
     assert "root info" not in caplog.text
@@ -110,45 +96,21 @@ def test_queued_logging_process_custom_config(caplog):
     assert "logger_2 info" in caplog.text
 
 
-def _queue_logged_process(log_queue, log_config=None):
-    from logging import getLogger
-
-    from trollflow2.logging import setup_queued_logging
-
-    setup_queued_logging(log_queue, log_config)
-
-    root = getLogger()
-    logger_1 = getLogger('logger_1')
-    logger_2 = getLogger('logger_2')
-
-    root.debug("root debug")
-    root.info("root info")
-    root.warning("root warning")
-
-    logger_1.debug("logger_1 debug")
-    logger_1.info("logger_1 info")
-    logger_1.warning("logger_1 warning")
-
-    logger_2.debug("logger_2 debug")
-    logger_2.info("logger_2 info")
-    logger_2.warning("logger_2 warning")
-
-
-LOG_CONFIG = {'version': 1,
-              'formatters': {'simple': {'format': '%(asctime)s - %(name)s - %(levelname)s - %(message)s'}},
-              'handlers': {'file': {'class': 'logging.handlers.BufferingHandler',
-                                    'capacity': 1,
-                                    'formatter': 'simple'}},
-              'root': {'level': 'INFO', 'handlers': ['file']}}
+BUFFERING_LOG_CONFIG = {'version': 1,
+                        'formatters': {'simple': {'format': '%(asctime)s - %(name)s - %(levelname)s - %(message)s'}},
+                        'handlers': {'file': {'class': 'logging.handlers.BufferingHandler',
+                                              'capacity': 1,
+                                              'formatter': 'simple'}},
+                        'root': {'level': 'INFO', 'handlers': ['file']}}
 
 
 def test_log_config_is_used_when_provided():
     """Test that the log config is used when provided."""
-    config = LOG_CONFIG
+    config = BUFFERING_LOG_CONFIG
 
     logger = logging.getLogger()
     with mock.patch("logging.handlers.BufferingHandler.emit", autospec=True) as emit:
-        with logging_on(log_queue, config=config):
+        with logging_on(LOG_QUEUE, config=config):
             assert not emit.called
             logger.warning("uh oh...")
             # we wait for the log record to go through the queue listener in
@@ -160,35 +122,94 @@ def test_log_config_is_used_when_provided():
 def test_logging_works(caplog):
     """Test that the logs get out there."""
     logger = logging.getLogger("something")
-    with logging_on(log_queue):
-        logging.getLogger().addHandler(caplog.handler)
-        logger.warning("oh no :(")
-        assert "oh no :(" in caplog.text
+    # logging.getLogger().addHandler(caplog.handler)
+    message = "oh no :("
+    with logging_on(LOG_QUEUE):
+        logger.warning(message)
+    assert message in caplog.text
 
 
-def fun(q, log_message):
+def fun(loggers, log_queue=None, log_config=None):
     """Fake a function to run."""
-    logger = logging.getLogger('for fun')
-    setup_queued_logging(q)
-    logger.debug(log_message)
+    setup_queued_logging(log_queue, config=log_config)
+    root_logger = logging.getLogger()
+    root_logger.debug("root debug")
+    root_logger.info("root info")
+    root_logger.warning("root warning")
+
+    for log_name in loggers:
+        logger = logging.getLogger(log_name)
+        logger.debug(f"{log_name} debug")
+        logger.info(f"{log_name} info")
+        logger.warning(f"{log_name} warning")
 
 
-def run_subprocess(log_message, queue):
+def run_subprocess(loggers, queue, config=None):
     """Run a subprocess."""
     from multiprocessing import get_context
     ctx = get_context('spawn')
-    proc = ctx.Process(target=fun, args=(queue, log_message))
+    proc = ctx.Process(target=fun, args=(loggers,), kwargs={"log_queue": queue, "log_config": config})
     proc.start()
     proc.join()
 
 
 @pytest.mark.skipif(sys.platform != "linux",
                     reason="Logging from a subprocess seems to work only on Linux")
-def test_logging_works_in_subprocess(caplog):
+def test_logging_works_in_subprocess_with_default_logging_config(caplog):
     """Test that the logs get out there, even from a subprocess."""
-    log_message = 'yeah, we are in a subprocess now'
-    with logging_on(log_queue):
-        logging.getLogger().addHandler(caplog.handler)
+    with logging_on(LOG_QUEUE):
 
-        run_subprocess(log_message, log_queue)
-        assert log_message in caplog.text
+        run_subprocess(["foo1", "foo2"], LOG_QUEUE)
+        assert no_duplicate_lines(caplog.text)
+        assert "root debug" in caplog.text
+        assert "foo1 debug" in caplog.text
+        assert "foo2 debug" in caplog.text
+        assert "root info" in caplog.text
+        assert "foo1 info" in caplog.text
+        assert "foo2 info" in caplog.text
+        assert "root warning" in caplog.text
+        assert "foo1 warning" in caplog.text
+        assert "foo2 warning" in caplog.text
+
+
+@pytest.mark.skipif(sys.platform != "linux",
+                    reason="Logging from a subprocess seems to work only on Linux")
+def test_logging_works_in_subprocess_not_double(tmp_path):
+    """Test that the logs get to a file, even from a subprocess, without duplicate lines."""
+    logfile = tmp_path / "mylog"
+    logger = logging.getLogger()
+    LOG_CONFIG_TO_FILE = {'version': 1,
+                          'formatters': {'simple': {'format': '%(asctime)s - %(name)s - %(levelname)s - %(message)s'}},
+                          'handlers': {'file': {'class': 'logging.FileHandler',
+                                                'filename': logfile,
+                                                'formatter': 'simple'}},
+                          "loggers":
+                              {'root': {'level': 'WARNING', 'handlers': ['file']},
+                               'foo1': {'level': 'DEBUG'},
+                               'foo2': {'level': 'INFO'},
+                               }
+                          }
+
+    with logging_on(LOG_QUEUE, LOG_CONFIG_TO_FILE):
+        run_subprocess(["foo1", "foo2"], LOG_QUEUE, LOG_CONFIG_TO_FILE)
+    time.sleep(.1)
+    logger.handlers[0].flush()
+    with open(logfile) as fd:
+        file_contents = fd.read()
+
+    assert no_duplicate_lines(file_contents)
+    assert "root debug" not in file_contents
+    assert "foo1 debug" in file_contents
+    assert "foo2 debug" not in file_contents
+    assert "root info" not in file_contents
+    assert "foo1 info" in file_contents
+    assert "foo2 info" in file_contents
+    assert "root warning" in file_contents
+    assert "foo1 warning" in file_contents
+    assert "foo2 warning" in file_contents
+
+
+def no_duplicate_lines(contents):
+    """Make sure there are no duplicate lines."""
+    lines = contents.strip().split("\n")
+    return len(lines) == len(set(lines))

--- a/trollflow2/tests/test_logging.py
+++ b/trollflow2/tests/test_logging.py
@@ -155,7 +155,7 @@ def test_logging_works_in_subprocess_with_default_logging_config(caplog):
     with logging_on():
 
         run_subprocess(["foo1", "foo2"])
-        assert no_duplicate_lines(caplog.text)
+        assert not duplicate_lines(caplog.text)
         assert "root debug" in caplog.text
         assert "foo1 debug" in caplog.text
         assert "foo2 debug" in caplog.text
@@ -192,7 +192,7 @@ def test_logging_works_in_subprocess_not_double(tmp_path):
     with open(logfile) as fd:
         file_contents = fd.read()
 
-    assert no_duplicate_lines(file_contents)
+    assert not duplicate_lines(file_contents)
     assert "root debug" not in file_contents
     assert "foo1 debug" in file_contents
     assert "foo2 debug" not in file_contents
@@ -204,7 +204,7 @@ def test_logging_works_in_subprocess_not_double(tmp_path):
     assert "foo2 warning" in file_contents
 
 
-def no_duplicate_lines(contents):
+def duplicate_lines(contents):
     """Make sure there are no duplicate lines."""
     lines = contents.strip().split("\n")
-    return len(lines) == len(set(lines))
+    return len(lines) != len(set(lines))


### PR DESCRIPTION
This PR implements an extra test for checking that the logging it not happening twice, even when writing the log to file.
More importantly, it also refactors the logging even more to remove the need to have log queue and log config parameters in the Runner class.

Unfortunately, due to the nature of the spawned process in that it does not inherit any environment from the parent process, this meant having to use a global variable. But I think the overall code quality is improving with that change.